### PR TITLE
Definition Generation contains excessively nested object that doesn't appear to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ node_modules
 /venv_3_11/*
 /package.json
 /package-lock.json
-/venv/*
+*/venv/*
+exhibitera/apps/configuration/*
+exhibitera/apps/definitions/*

--- a/exhibitera/apps/helper_files.py
+++ b/exhibitera/apps/helper_files.py
@@ -80,9 +80,6 @@ def write_json(data: dict, path: str | os.PathLike, append: bool = False, compac
 
     success = True
     reason = ""
-    """Clear out an extraneous property being set in the frontend. """
-    if 's' in data:
-        del data['s']
 
     if append:
         mode = 'a'

--- a/exhibitera/apps/helper_files.py
+++ b/exhibitera/apps/helper_files.py
@@ -80,6 +80,9 @@ def write_json(data: dict, path: str | os.PathLike, append: bool = False, compac
 
     success = True
     reason = ""
+    """Clear out an extraneous property being set in the frontend. """
+    if 's' in data:
+        del data['s']
 
     if append:
         mode = 'a'

--- a/exhibitera/apps/js/exhibitera_setup_common.js
+++ b/exhibitera/apps/js/exhibitera_setup_common.js
@@ -256,7 +256,12 @@ export function updateWorkingDefinition (property, value) {
   // 'property' should be an array of subproperties, e.g., ["style", "color", 'headerColor']
   // for definition.style.color.headerColor
 
-  exCommon.setObjectProperty($('#definitionSaveButton').data('workingDefinition'), property, value)
+  if(property && property[0].length<=1){
+    //occasionally the color library is providing a poperty with a large amount of single entries that clog up the definition json
+    console.log(`skipping ${property}`)
+    return;
+  }
+  exCommon.setObjectProperty($('#definitionSaveButton').data('workingDefinition'), property, value);
 }
 
 export function createLoginEventListeners () {
@@ -481,10 +486,12 @@ function _createAdvancedColorPicker (el, name, path) {
 
   // Add event listeners
   document.getElementById(`ACPModeSelect_${id}`).addEventListener('change', (event) => {
+    
     _onAdvancedColorPickerModeChange(id, path, event.target.value)
   })
 
   document.getElementById(`ACPColor_${id}`).addEventListener('change', (event) => {
+   
     updateWorkingDefinition([...path, 'color'], event.target.value)
     previewDefinition(true)
   })

--- a/exhibitera/apps/js/exhibitera_setup_common.js
+++ b/exhibitera/apps/js/exhibitera_setup_common.js
@@ -486,12 +486,10 @@ function _createAdvancedColorPicker (el, name, path) {
 
   // Add event listeners
   document.getElementById(`ACPModeSelect_${id}`).addEventListener('change', (event) => {
-    
     _onAdvancedColorPickerModeChange(id, path, event.target.value)
   })
 
   document.getElementById(`ACPColor_${id}`).addEventListener('change', (event) => {
-   
     updateWorkingDefinition([...path, 'color'], event.target.value)
     previewDefinition(true)
   })


### PR DESCRIPTION
I noticed when Exhibitera is generating definition files for applications its generating a pretty extraneous nested object that I don't believe are used anywhere. 
Example Definition file before:
```
{
  "a": {
    "p": {
      "p": {
        "e": {
          "a": {
            "r": {
              "a": {
                "n": {
                  "c": {
                    "e": {
                      ">": {
                        "b": {
                          "a": {
                            "c": {
                              "k": {
                                "g": {
                                  "r": {
                                    "o": {
                                      "u": {
                                        "n": {
                                          "d": {
                                            "mode": "color"
                                          }
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "app": "word_cloud_input",
  "appearance": {
    "background": {
      "color": "#fff",
      "mode": "color"
    },
    "font": {
      "clear": "../_fonts/OpenSans-Regular.ttf",
      "input": "../_fonts/OpenSans-Regular.ttf",
      "prompt": "../_fonts/OpenSans-Bold.ttf",
      "submit": "../_fonts/OpenSans-Regular.ttf"
    }
  },
  "attractor": {},
  "behavior": {},
  "content": {
    "localization": {}
  },
  "exhibitera_version": 5,
  "lastEditedDate": "2024-04-22T01:23:38.458Z",
  "name": "",
  "uuid": "01dfb539-67b3-4ed6-83f1-2d3a89ab52c9"
}
```
Example After:
```
{
  "app": "media_browser",
  "exhibitera_version": 5,
  "languages": {},
  "lastEditedDate": "2024-04-26T22:52:09.077Z",
  "name": "Another Test",
  "style": {
    "background": {
      "color": "#ff1111",
      "mode": "color"
    },
    "color": {
      "filterBackgroundColor": "#bc1717",
      "filterLabelColor": "#bc5858",
      "filterTextColor": "#a05a5a",
      "titleColor": "#e32222"
    },
    "font": {
      "Lightbox_caption": "../_fonts/OpenSans-Regular.ttf",
      "Lightbox_credit": "../_fonts/OpenSans-LightItalic.ttf",
      "Lightbox_title": "../_fonts/OpenSans-Bold.ttf",
      "Title": "../_fonts/OpenSans-Bold.ttf",
      "filter_label": "../_fonts/OpenSans-Bold.ttf",
      "filter_text": "../_fonts/OpenSans-Regular.ttf"
    },
    "layout": {},
    "text_size": {}
  },
  "uuid": "e2b0c66e-ebd5-4667-b213-8abca1fdea4a"
}

```

I added a filter to the front end input, as well as where it get saved in case there is an instance not covered by the frontend changes. 