### PR TITLE
Adding in initial support for a Keyboard to Word Cloud 

### DIFF
--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -212,7 +212,7 @@
                 <div class="col-12 col-md-6 col-lg-4">
                   <label for="collectionNameInput" class="form-label">
                     Physical Keyboard
-                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enable input from a physical keyboard, this will hide the onscreen keyboard" style="font-size: 0.55em;">?</span>
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enable input from a physical keyboard, this will hide the onscreen keyboard. Additionally ensure that your keyboard is limited to only Alphanumeric input." style="font-size: 0.55em;">?</span>
                   </label>
                   <div class="form-check form-check-inline">
                     <input type="checkbox" class="form-check-input" id="enableKeyboardInput">

--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -225,7 +225,7 @@
                     Max character count
                     <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="The maximum number of characters entered (including spaces). Set to -1 for infinite length." style="font-size: 0.55em;">?</span>
                   </label>
-                  <input type="number" class="form-control" id="maxCharCount" value="-1">
+                  <input type="number" class="form-control" id="maxCharacterCount" value="-1">
                 </div>
               </div>
 

--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -222,10 +222,10 @@
                 </div>
                 <div class="col-12 col-md-6 col-lg-4">
                   <label for="collectionNameInput" class="form-label">
-                    Max Word Length
-                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="The maximum length of words entered. Set to -1 for infinite length" style="font-size: 0.55em;">?</span>
+                    Max Character Count
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="The maximum number of characters entered (Includes spaces). Set to -1 for infinite length" style="font-size: 0.55em;">?</span>
                   </label>
-                  <input type="number" class="form-control" id="maxInputLength" value="-1">
+                  <input type="number" class="form-control" id="maxCharCount" value="-1">
                 </div>
               </div>
 

--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -289,6 +289,12 @@
                   </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg-4">
+                  <label for="colorPicker_input-hint" class="form-label">Input Hint Text</label>
+                  <div>
+                    <input id="colorPicker_input-hint" type="text" class="coloris form-control" value="#776767" data-property="input-font-hint" data-default="#776767">
+                  </div>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-4">
                   <label for="colorPicker_input-background" class="form-label">Input background</label>
                   <div>
                     <input id="colorPicker_input-background" type="text" class="coloris form-control" value="#e9ecef" data-property="input-background" data-default="#e9ecef">

--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -209,6 +209,24 @@
                   </label>
                   <input type="text" class="form-control" id="collectionNameInput">
                 </div>
+                <div class="col-12 col-md-6 col-lg-4">
+                  <label for="collectionNameInput" class="form-label">
+                    Physical Keyboard
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enable input from a physical keyboard" style="font-size: 0.55em;">?</span>
+                  </label>
+                  <div class="form-check form-check-inline">
+                    <input type="checkbox" class="form-check-input" id="enableKeyboardInput">
+                    <label class="form-check-label" for="enableKeyboardInput">Enable Keyboard</label>
+                  </div>
+                  
+                </div>
+                <div class="col-12 col-md-6 col-lg-4">
+                  <label for="collectionNameInput" class="form-label">
+                    Max Word Length
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="The maximum length of words entered. Set to -1 for infinite length" style="font-size: 0.55em;">?</span>
+                  </label>
+                  <input type="number" class="form-control" id="maxInputLength" value="-1">
+                </div>
               </div>
 
               <h3 class="mt-2">Content</h3>

--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -212,7 +212,7 @@
                 <div class="col-12 col-md-6 col-lg-4">
                   <label for="collectionNameInput" class="form-label">
                     Physical Keyboard
-                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enable input from a physical keyboard" style="font-size: 0.55em;">?</span>
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enable input from a physical keyboard, this will hide the onscreen keyboard" style="font-size: 0.55em;">?</span>
                   </label>
                   <div class="form-check form-check-inline">
                     <input type="checkbox" class="form-check-input" id="enableKeyboardInput">

--- a/exhibitera/apps/word_cloud/setup_input.html
+++ b/exhibitera/apps/word_cloud/setup_input.html
@@ -211,8 +211,8 @@
                 </div>
                 <div class="col-12 col-md-6 col-lg-4">
                   <label for="collectionNameInput" class="form-label">
-                    Physical Keyboard
-                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enable input from a physical keyboard, this will hide the onscreen keyboard. Additionally ensure that your keyboard is limited to only Alphanumeric input." style="font-size: 0.55em;">?</span>
+                    Physical keyboard
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Enabling input from a physical keyboard will hide the onscreen keyboard. You should use a kiosk application to ensure users can't alt-tab to escape." style="font-size: 0.55em;">?</span>
                   </label>
                   <div class="form-check form-check-inline">
                     <input type="checkbox" class="form-check-input" id="enableKeyboardInput">
@@ -222,8 +222,8 @@
                 </div>
                 <div class="col-12 col-md-6 col-lg-4">
                   <label for="collectionNameInput" class="form-label">
-                    Max Character Count
-                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="The maximum number of characters entered (Includes spaces). Set to -1 for infinite length" style="font-size: 0.55em;">?</span>
+                    Max character count
+                    <span class="badge bg-info ml-1 align-middle text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="The maximum number of characters entered (including spaces). Set to -1 for infinite length." style="font-size: 0.55em;">?</span>
                   </label>
                   <input type="number" class="form-control" id="maxCharCount" value="-1">
                 </div>
@@ -289,7 +289,7 @@
                   </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg-4">
-                  <label for="colorPicker_input-hint" class="form-label">Input Hint Text</label>
+                  <label for="colorPicker_input-hint" class="form-label">Character count</label>
                   <div>
                     <input id="colorPicker_input-hint" type="text" class="coloris form-control" value="#776767" data-property="input-font-hint" data-default="#776767">
                   </div>

--- a/exhibitera/apps/word_cloud/setup_input.js
+++ b/exhibitera/apps/word_cloud/setup_input.js
@@ -221,6 +221,11 @@ document.getElementById('collectionNameInput').addEventListener('change', (event
 })
 document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
   exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked);
+  if(event.target.checked){
+    document.getElementById("previewFrame").src ='../word_cloud_input.html?standalone=true';
+  }else{
+    document.getElementById('previewFrame').src ='../word_cloud_input.html?standalone=true';
+  }
   exSetup.previewDefinition(true)
 });
 document.getElementById('maxInputLength').addEventListener('change',(event)=>{

--- a/exhibitera/apps/word_cloud/setup_input.js
+++ b/exhibitera/apps/word_cloud/setup_input.js
@@ -25,7 +25,7 @@ function initializeDefinition () {
           attractor: {},
           behavior: {},
           enableKeyboard:false,
-          maxWordLength:-1,
+          maxCharCount:-1,
           content: {
             localization: {}
           }
@@ -41,7 +41,7 @@ function initializeDefinition () {
           attractor: {},
           behavior: {},
           enableKeyboard:false,
-          maxWordLength:-1,
+          maxCharCount:-1,
           content: {
             localization: {}
           }
@@ -63,7 +63,7 @@ async function clearDefinitionInput (full = true) {
   document.getElementById('definitionNameInput').value = ''
   document.getElementById('collectionNameInput').value = ''
   document.getElementById('enableKeyboardInput').checked=false;
-  document.getElementById('maxInputLength').value='-1';
+  document.getElementById('maxCharCount').value='-1';
   // Content details
   document.getElementById('promptInput').value = ''
   Array.from(document.querySelectorAll('.localization-input')).forEach((el) => {
@@ -112,10 +112,10 @@ function editDefinition (uuid = '') {
   }else{
     document.getElementById('enableKeyboardInput').checked = false;
   }
-  if('max_word_length' in def.behavior){
-    document.getElementById('maxInputLength').value = def.behavior.max_word_length;
+  if('max_char_count' in def.behavior){
+    document.getElementById('maxCharCount').value = def.behavior.max_char_count;
   }else{
-    document.getElementById('maxInputLength').value = -1;
+    document.getElementById('maxCharCount').value = -1;
   }
   // Content
   if ('prompt' in def.content) {
@@ -228,13 +228,13 @@ document.getElementById('enableKeyboardInput').addEventListener('change',(event)
   }
   exSetup.previewDefinition(true)
 });
-document.getElementById('maxInputLength').addEventListener('change',(event)=>{
-  exSetup.updateWorkingDefinition(['behavior', 'max_word_length'], event.target.value);
-  exSetup.previewDefinition(true);document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
-    console.log(event.target.checked);
-    exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked)
-    exSetup.previewDefinition(true)
-  });
+document.getElementById('maxCharCount').addEventListener('change',(event)=>{
+  exSetup.updateWorkingDefinition(['behavior', 'max_char_count'], event.target.value);
+  exSetup.previewDefinition(true);
+});
+document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
+  exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked)
+  exSetup.previewDefinition(true)
 });
 // Content
 document.getElementById('promptInput').addEventListener('change', (event) => {

--- a/exhibitera/apps/word_cloud/setup_input.js
+++ b/exhibitera/apps/word_cloud/setup_input.js
@@ -4,7 +4,7 @@ import * as exCommon from '../js/exhibitera_app_common.js'
 import * as exSetup from '../js/exhibitera_setup_common.js'
 import * as exFileSelect from '../js/exhibitera_file_select_modal.js'
 
-function initializeDefinition () {
+function initializeDefinition() {
   // Create a blank definition at save it to workingDefinition.
 
   return new Promise(function (resolve, reject) {
@@ -23,9 +23,10 @@ function initializeDefinition () {
             }
           },
           attractor: {},
-          behavior: {},
-          enableKeyboard:false,
-          maxCharCount:-1,
+          behavior: {
+            enable_keyboard_input: false,
+            max_character_count: -1,
+          },
           content: {
             localization: {}
           }
@@ -39,9 +40,10 @@ function initializeDefinition () {
             }
           },
           attractor: {},
-          behavior: {},
-          enableKeyboard:false,
-          maxCharCount:-1,
+          behavior: {
+            enable_keyboard_input: false,
+            max_character_count: -1,
+          },
           content: {
             localization: {}
           }
@@ -52,7 +54,7 @@ function initializeDefinition () {
   })
 }
 
-async function clearDefinitionInput (full = true) {
+async function clearDefinitionInput(full = true) {
   // Clear all input related to a defnition
 
   if (full === true) {
@@ -62,8 +64,8 @@ async function clearDefinitionInput (full = true) {
   // Definition details
   document.getElementById('definitionNameInput').value = ''
   document.getElementById('collectionNameInput').value = ''
-  document.getElementById('enableKeyboardInput').checked=false;
-  document.getElementById('maxCharCount').value='-1';
+  document.getElementById('enableKeyboardInput').checked = false;
+  document.getElementById('maxCharacterCount').value = '-1';
   // Content details
   document.getElementById('promptInput').value = ''
   Array.from(document.querySelectorAll('.localization-input')).forEach((el) => {
@@ -93,7 +95,7 @@ async function clearDefinitionInput (full = true) {
   document.getElementById('promptTextSizeSlider').value = 0
 }
 
-function editDefinition (uuid = '') {
+function editDefinition(uuid = '') {
   // Populate the given definition for editing.
 
   clearDefinitionInput(false)
@@ -107,15 +109,15 @@ function editDefinition (uuid = '') {
   } else {
     document.getElementById('collectionNameInput').value = ''
   }
-  if('enable_keyboard_input' in def.behavior){
+  if ('enable_keyboard_input' in def.behavior) {
     document.getElementById('enableKeyboardInput').checked = def.behavior.enable_keyboard_input;
-  }else{
+  } else {
     document.getElementById('enableKeyboardInput').checked = false;
   }
-  if('max_char_count' in def.behavior){
-    document.getElementById('maxCharCount').value = def.behavior.max_char_count;
-  }else{
-    document.getElementById('maxCharCount').value = -1;
+  if ('max_character_count' in def.behavior) {
+    document.getElementById('maxCharacterCount').value = def.behavior.max_character_count;
+  } else {
+    document.getElementById('maxCharacterCount').value = -1;
   }
   // Content
   if ('prompt' in def.content) {
@@ -163,7 +165,7 @@ function editDefinition (uuid = '') {
   exSetup.previewDefinition()
 }
 
-function saveDefinition () {
+function saveDefinition() {
   // Collect inputted information to save the definition
 
   const definition = $('#definitionSaveButton').data('workingDefinition')
@@ -189,7 +191,7 @@ function saveDefinition () {
 }
 
 // Set up the color pickers
-function setUpColorPickers () {
+function setUpColorPickers() {
   Coloris({
     el: '.coloris',
     theme: 'pill',
@@ -219,22 +221,18 @@ document.getElementById('collectionNameInput').addEventListener('change', (event
   exSetup.updateWorkingDefinition(['behavior', 'collection_name'], event.target.value)
   exSetup.previewDefinition(true)
 })
-document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
+document.getElementById('enableKeyboardInput').addEventListener('change', (event) => {
   exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked);
-  if(event.target.checked){
-    document.getElementById("previewFrame").src ='../word_cloud_input.html?standalone=true';
-  }else{
-    document.getElementById('previewFrame').src ='../word_cloud_input.html?standalone=true';
+  if (event.target.checked) {
+    document.getElementById("previewFrame").src = '../word_cloud_input.html?standalone=true';
+  } else {
+    document.getElementById('previewFrame').src = '../word_cloud_input.html?standalone=true';
   }
   exSetup.previewDefinition(true)
 });
-document.getElementById('maxCharCount').addEventListener('change',(event)=>{
-  exSetup.updateWorkingDefinition(['behavior', 'max_char_count'], event.target.value);
+document.getElementById('maxCharacterCount').addEventListener('change', (event) => {
+  exSetup.updateWorkingDefinition(['behavior', 'max_character_count'], parseInt(event.target.value));
   exSetup.previewDefinition(true);
-});
-document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
-  exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked)
-  exSetup.previewDefinition(true)
 });
 // Content
 document.getElementById('promptInput').addEventListener('change', (event) => {

--- a/exhibitera/apps/word_cloud/setup_input.js
+++ b/exhibitera/apps/word_cloud/setup_input.js
@@ -24,6 +24,8 @@ function initializeDefinition () {
           },
           attractor: {},
           behavior: {},
+          enableKeyboard:false,
+          maxWordLength:-1,
           content: {
             localization: {}
           }
@@ -38,6 +40,8 @@ function initializeDefinition () {
           },
           attractor: {},
           behavior: {},
+          enableKeyboard:false,
+          maxWordLength:-1,
           content: {
             localization: {}
           }
@@ -58,7 +62,8 @@ async function clearDefinitionInput (full = true) {
   // Definition details
   document.getElementById('definitionNameInput').value = ''
   document.getElementById('collectionNameInput').value = ''
-
+  document.getElementById('enableKeyboardInput').checked=false;
+  document.getElementById('maxInputLength').value='-1';
   // Content details
   document.getElementById('promptInput').value = ''
   Array.from(document.querySelectorAll('.localization-input')).forEach((el) => {
@@ -102,7 +107,16 @@ function editDefinition (uuid = '') {
   } else {
     document.getElementById('collectionNameInput').value = ''
   }
-
+  if('enable_keyboard_input' in def.behavior){
+    document.getElementById('enableKeyboardInput').checked = def.behavior.enable_keyboard_input;
+  }else{
+    document.getElementById('enableKeyboardInput').checked = false;
+  }
+  if('max_word_length' in def.behavior){
+    document.getElementById('maxInputLength').value = def.behavior.max_word_length;
+  }else{
+    document.getElementById('maxInputLength').value = -1;
+  }
   // Content
   if ('prompt' in def.content) {
     document.getElementById('promptInput').value = def.content.prompt
@@ -200,13 +214,23 @@ setTimeout(setUpColorPickers, 100)
 
 // Add event listeners
 // -------------------------------------------------------------
-
 // Settings
 document.getElementById('collectionNameInput').addEventListener('change', (event) => {
   exSetup.updateWorkingDefinition(['behavior', 'collection_name'], event.target.value)
   exSetup.previewDefinition(true)
 })
-
+document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
+  exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked);
+  exSetup.previewDefinition(true)
+});
+document.getElementById('maxInputLength').addEventListener('change',(event)=>{
+  exSetup.updateWorkingDefinition(['behavior', 'max_word_length'], event.target.value);
+  exSetup.previewDefinition(true);document.getElementById('enableKeyboardInput').addEventListener('change',(event)=>{
+    console.log(event.target.checked);
+    exSetup.updateWorkingDefinition(['behavior', 'enable_keyboard_input'], event.target.checked)
+    exSetup.previewDefinition(true)
+  });
+});
 // Content
 document.getElementById('promptInput').addEventListener('change', (event) => {
   exSetup.updateWorkingDefinition(['content', 'prompt'], event.target.value)

--- a/exhibitera/apps/word_cloud/word_cloud_input.css
+++ b/exhibitera/apps/word_cloud/word_cloud_input.css
@@ -15,6 +15,7 @@
     --clear-font: 'clear-default';
     --input-font: "input-default";
     --prompt-font-adjust: 0;
+    --input-font-hint-color:#776767;
 }
 
 html {
@@ -38,11 +39,22 @@ html {
     background-size: cover;
     background-position: center
   }
+  .annotatedInput{
+    position:relative;
+  }
   #inputField {
     font-size: 3vmax;
     font-family: var(--input-font);
     background-color: var(--input-background-color);
     color: var(--input-color);
+  }
+  #characterCount{
+    position: absolute;
+    top: 1.25rem;
+    right: 2rem;
+    font-size: 2vmax;
+    font-family: var(--input-font);
+    color: var(--input-font-hint-color);
   }
   #clearButton {
     font-size: 3vmax;

--- a/exhibitera/apps/word_cloud/word_cloud_input.js
+++ b/exhibitera/apps/word_cloud/word_cloud_input.js
@@ -1,15 +1,13 @@
 /* global swearList */
 
 import * as exCommon from '../js/exhibitera_app_common.js'
-let maxWordLength = -1;
+let maxCharCount = -1;
 let keyboard;
 function AddKeyboardListeners(maxLength) {
   window.addEventListener('keydown', (event) => {
     let input = document.querySelector('#inputField')
     let value = input.value;
-    console.log(value.length);
-    console.log(maxWordLength);
-    if (maxWordLength > 0) {
+    if (maxCharCount > 0) {
       if (value.length >= maxLength && event.key !== 'Backspace') {
         return;
       }
@@ -112,12 +110,12 @@ function loadDefinition(definition) {
     collectionName = 'default'
   }
   let showKeyboard = true;
-  if ('max_word_length' in definition.behavior) {
-    maxWordLength = definition.behavior.max_word_length;
+  if ('max_char_count' in definition.behavior) {
+    maxCharCount = definition.behavior.max_char_count;
   }
   if ('enable_keyboard_input' in definition.behavior) {
     if (definition.behavior.enable_keyboard_input) {
-      AddKeyboardListeners(maxWordLength);
+      AddKeyboardListeners(maxCharCount);
       showKeyboard = false;
     }
   }
@@ -134,8 +132,8 @@ function loadDefinition(definition) {
           '{space}'
         ]
       },
-      maxLength: maxWordLength > 0 ? {
-        default: maxWordLength
+      maxLength: maxCharCount > 0 ? {
+        default: maxCharCount
       } : {}
     })
 

--- a/exhibitera/apps/word_cloud/word_cloud_input.js
+++ b/exhibitera/apps/word_cloud/word_cloud_input.js
@@ -1,14 +1,43 @@
 /* global swearList */
 
 import * as exCommon from '../js/exhibitera_app_common.js'
-
-function clear () {
+let maxWordLength = -1;
+let keyboard;
+function AddKeyboardListeners(maxLength) {
+  window.addEventListener('keydown', (event) => {
+    let input = document.querySelector('#inputField')
+    let value = input.value;
+    console.log(value.length);
+    console.log(maxWordLength);
+    if (maxWordLength > 0) {
+      if (value.length >= maxLength && event.key !== 'Backspace') {
+        return;
+      }
+    }
+    let newVal = value;
+    switch (event.key) {
+      case 'Backspace':
+        newVal = value.slice(0, value.length - 1);
+        break;
+      case 'Shift':
+      case 'Enter':
+        break;
+      case 'Space':
+        newVal = value + ' ';
+        break;
+      default:
+        newVal = value + event.key
+    }
+    input.value = newVal;
+  })
+}
+function clear() {
   $('#inputField').val('')
   keyboard.input.default = ''
   keyboard.input.inputField = ''
 }
 
-function getCleanText () {
+function getCleanText() {
   // Run the profanity checker on the input field
 
   $('#profanityCheckingDiv').html($('#inputField').val()).profanityFilter({ customSwears: swearList, replaceWith: '#' })
@@ -17,7 +46,7 @@ function getCleanText () {
   return ($('#profanityCheckingDiv').html().trim())
 }
 
-function sendTextToServer () {
+function sendTextToServer() {
   // Send the server the text that the user has inputted
   const text = getCleanText()
   const requestDict = {
@@ -51,7 +80,7 @@ function sendTextToServer () {
   }
 }
 
-function updateFunc (update) {
+function updateFunc(update) {
   // Read updates for word cloud-specific actions and act on them
 
   // This should be last to make sure the path has been updated
@@ -64,7 +93,7 @@ function updateFunc (update) {
   }
 }
 
-function loadDefinition (definition) {
+function loadDefinition(definition) {
   // Set up a new interface to collect input
 
   // Parse the settings and make the appropriate changes
@@ -78,29 +107,56 @@ function loadDefinition (definition) {
   } else {
     collectionName = 'default'
   }
+  let showKeyboard = true;
+  if ('max_word_length' in definition.behavior) {
+    maxWordLength = definition.behavior.max_word_length;
+  }
+  if ('enable_keyboard_input' in definition.behavior) {
+    if (definition.behavior.enable_keyboard_input) {
+      AddKeyboardListeners(maxWordLength);
+      showKeyboard = false;
+    }
+  }
+  if (showKeyboard || exCommon.config.hideKeyboard) {
+    //Enable keyboard 
+    keyboard = new Keyboard({
+      onChange: input => onChange(input),
+      onKeyPress: button => onKeyPress(button),
+      layout: {
+        default: [
+          'Q W E R T Y U I O P',
+          'A S D F G H J K L',
+          'Z X C V B N M {bksp}',
+          '{space}'
+        ]
+      },
+      maxLength: maxWordLength > 0 ? {
+        default: maxWordLength
+      } : {}
+    })
 
-  // Localization options
-  if ('placeholder' in definition.content.localization && definition.content.localization.placeholder.trim() !== '') {
-    document.getElementById('inputField').placeholder = definition.content.localization.placeholder
-  } else {
-    document.getElementById('inputField').placeholder = 'Type to enter response'
+    // Localization options
+    if ('placeholder' in definition.content.localization && definition.content.localization.placeholder.trim() !== '') {
+      document.getElementById('inputField').placeholder = definition.content.localization.placeholder
+    } else {
+      document.getElementById('inputField').placeholder = 'Type to enter response'
+    }
+    if ('clear' in definition.content.localization && definition.content.localization.clear.trim() !== '') {
+      document.getElementById('clearButton').innerHTML = definition.content.localization.clear
+    } else {
+      document.getElementById('clearButton').innerHTML = 'Clear'
+    }
+    if ('submit' in definition.content.localization && definition.content.localization.submit.trim() !== '') {
+      document.getElementById('submitButton').innerHTML = definition.content.localization.submit
+    } else {
+      document.getElementById('submitButton').innerHTML = 'Submit'
+    }
+    if ('backspace' in definition.content.localization && definition.content.localization.backspace.trim() !== '') {
+      document.querySelector('.hg-button-bksp').querySelector('span').innerHTML = definition.content.localization.backspace
+    } else {
+      document.querySelector('.hg-button-bksp').querySelector('span').innerHTML = 'backspace'
+    }
   }
-  if ('clear' in definition.content.localization && definition.content.localization.clear.trim() !== '') {
-    document.getElementById('clearButton').innerHTML = definition.content.localization.clear
-  } else {
-    document.getElementById('clearButton').innerHTML = 'Clear'
-  }
-  if ('submit' in definition.content.localization && definition.content.localization.submit.trim() !== '') {
-    document.getElementById('submitButton').innerHTML = definition.content.localization.submit
-  } else {
-    document.getElementById('submitButton').innerHTML = 'Submit'
-  }
-  if ('backspace' in definition.content.localization && definition.content.localization.backspace.trim() !== '') {
-    document.querySelector('.hg-button-bksp').querySelector('span').innerHTML = definition.content.localization.backspace
-  } else {
-    document.querySelector('.hg-button-bksp').querySelector('span').innerHTML = 'backspace'
-  }
-
   const root = document.querySelector(':root')
 
   // Color settings
@@ -158,8 +214,6 @@ function loadDefinition (definition) {
       root.style.setProperty('--' + key + '-font-adjust', value)
     })
   }
- //Enable keyboard 
- 
   // Send a thumbnail to the helper
   setTimeout(() => exCommon.saveScreenshotAsThumbnail(definition.uuid + '.png'), 100)
 }
@@ -170,36 +224,25 @@ const Keyboard = window.SimpleKeyboard.default
 document.querySelectorAll('.input').forEach(input => {
   input.addEventListener('focus', onInputFocus)
 })
-function onInputFocus (event) {
+function onInputFocus(event) {
   keyboard.setOptions({
     inputName: event.target.id
   })
 }
-function onInputChange (event) {
+function onInputChange(event) {
   keyboard.setInput(event.target.value, event.target.id)
 }
-function onKeyPress (button) {
+function onKeyPress(button) {
   if (button === '{lock}' || button === '{shift}') handleShiftButton()
 }
 document.querySelector('#inputField').addEventListener('input', event => {
   keyboard.setInput(event.target.value)
 })
-function onChange (input) {
+function onChange(input) {
   document.querySelector('#inputField').value = input
 }
 
-const keyboard = new Keyboard({
-  onChange: input => onChange(input),
-  onKeyPress: button => onKeyPress(button),
-  layout: {
-    default: [
-      'Q W E R T Y U I O P',
-      'A S D F G H J K L',
-      'Z X C V B N M {bksp}',
-      '{space}'
-    ]
-  }
-})
+
 
 exCommon.configureApp({
   name: 'word_cloud_input',
@@ -213,21 +256,3 @@ let collectionName = 'default'
 
 document.getElementById('clearButton').addEventListener('click', clear)
 document.getElementById('submitButton').addEventListener('click', sendTextToServer)
-document.addEventListener('keydown',(event)=>{
-  console.log(event.key);
-  let input = document.querySelector('#inputField')
-  let value = input.value;
-  let newVal = value;
-  switch(event.key){
-    case 'Backspace':
-      newVal = value.slice(0,value.length-1);
-      break;
-    case 'Shift':
-    case 'Enter':
-      break;
-    
-    default:
-      newVal = value +event.key
-  }
-  input.value = newVal;
-})

--- a/exhibitera/apps/word_cloud/word_cloud_input.js
+++ b/exhibitera/apps/word_cloud/word_cloud_input.js
@@ -19,6 +19,10 @@ function AddKeyboardListeners(maxLength) {
       case 'Backspace':
         newVal = value.slice(0, value.length - 1);
         break;
+      case 'Meta':
+      case 'Control':
+      case 'CapsLock':
+      case 'Esc':
       case 'Shift':
       case 'Enter':
         break;

--- a/exhibitera/apps/word_cloud/word_cloud_input.js
+++ b/exhibitera/apps/word_cloud/word_cloud_input.js
@@ -1,14 +1,14 @@
 /* global swearList */
 
 import * as exCommon from '../js/exhibitera_app_common.js'
-let maxCharCount = -1;
+let maxCharacterCount = -1;
 const Keyboard = window.SimpleKeyboard.default;
 let keyboard ='';
 function AddKeyboardListeners(maxLength) {
   window.addEventListener('keydown', (event) => {
     let input = document.querySelector('#inputField')
     let value = input.value;
-    if (maxCharCount > 0) {
+    if (maxCharacterCount > 0) {
       if (value.length >= maxLength && event.key !== 'Backspace') {
         return;
       }
@@ -36,9 +36,9 @@ function AddKeyboardListeners(maxLength) {
   })
 }
 function setLengthHint(length){
-  if(maxCharCount >0) {
+  if(maxCharacterCount >0) {
     if(length > 0){
-      document.getElementById('characterCount').innerText =`${length}/${maxCharCount}`;
+      document.getElementById('characterCount').innerText =`${length}/${maxCharacterCount}`;
     }else{
       document.getElementById('characterCount').innerText ='';
     }
@@ -123,12 +123,13 @@ function loadDefinition(definition) {
     collectionName = 'default'
   }
   let showKeyboard = true;
-  if ('max_char_count' in definition.behavior) {
-    maxCharCount = definition.behavior.max_char_count;
+  if ('max_character_count' in definition.behavior) {
+    maxCharacterCount = definition.behavior.max_character_count;
+    console.log(maxCharacterCount);
   }
   if ('enable_keyboard_input' in definition.behavior) {
     if (definition.behavior.enable_keyboard_input) {
-      AddKeyboardListeners(maxCharCount);
+      AddKeyboardListeners(maxCharacterCount);
       showKeyboard = false;
     }
   }
@@ -145,8 +146,8 @@ function loadDefinition(definition) {
           '{space}'
         ]
       },
-      maxLength: maxCharCount > 0 ? {
-        default: maxCharCount
+      maxLength: maxCharacterCount > 0 ? {
+        default: maxCharacterCount
       } : {}
     })
 

--- a/exhibitera/apps/word_cloud/word_cloud_input.js
+++ b/exhibitera/apps/word_cloud/word_cloud_input.js
@@ -2,7 +2,8 @@
 
 import * as exCommon from '../js/exhibitera_app_common.js'
 let maxCharCount = -1;
-let keyboard;
+const Keyboard = window.SimpleKeyboard.default;
+let keyboard ='';
 function AddKeyboardListeners(maxLength) {
   window.addEventListener('keydown', (event) => {
     let input = document.querySelector('#inputField')
@@ -31,12 +32,24 @@ function AddKeyboardListeners(maxLength) {
         newVal = value + event.key
     }
     input.value = newVal;
+    setLengthHint(newVal.length);
   })
+}
+function setLengthHint(length){
+  if(maxCharCount >0) {
+    if(length > 0){
+      document.getElementById('characterCount').innerText =`${length}/${maxCharCount}`;
+    }else{
+      document.getElementById('characterCount').innerText ='';
+    }
+  }
 }
 function clear() {
   $('#inputField').val('')
+  if(keyboard){
   keyboard.input.default = ''
   keyboard.input.inputField = ''
+  }
 }
 
 function getCleanText() {
@@ -220,14 +233,14 @@ function loadDefinition(definition) {
   setTimeout(() => exCommon.saveScreenshotAsThumbnail(definition.uuid + '.png'), 100)
 }
 
-const Keyboard = window.SimpleKeyboard.default
+
 
 // Add a listener to each input so we direct keyboard input to the right one
 document.querySelectorAll('.input').forEach(input => {
   input.addEventListener('focus', onInputFocus)
 })
 function onInputFocus(event) {
-  keyboard.setOptions({
+  keyboard?.setOptions({
     inputName: event.target.id
   })
 }
@@ -238,10 +251,11 @@ function onKeyPress(button) {
   if (button === '{lock}' || button === '{shift}') handleShiftButton()
 }
 document.querySelector('#inputField').addEventListener('input', event => {
-  keyboard.setInput(event.target.value)
+  keyboard?.setInput(event.target.value)
 })
 function onChange(input) {
   document.querySelector('#inputField').value = input
+  setLengthHint(input.length);
 }
 
 

--- a/exhibitera/apps/word_cloud/word_cloud_input.js
+++ b/exhibitera/apps/word_cloud/word_cloud_input.js
@@ -125,7 +125,7 @@ function loadDefinition (definition) {
     })
   }
 
-  // Backgorund settings
+  // Background settings
   if ('background' in definition.appearance) {
     exCommon.setBackground(definition.appearance.background, root, '#fff')
   }
@@ -158,7 +158,8 @@ function loadDefinition (definition) {
       root.style.setProperty('--' + key + '-font-adjust', value)
     })
   }
-
+ //Enable keyboard 
+ 
   // Send a thumbnail to the helper
   setTimeout(() => exCommon.saveScreenshotAsThumbnail(definition.uuid + '.png'), 100)
 }
@@ -212,3 +213,21 @@ let collectionName = 'default'
 
 document.getElementById('clearButton').addEventListener('click', clear)
 document.getElementById('submitButton').addEventListener('click', sendTextToServer)
+document.addEventListener('keydown',(event)=>{
+  console.log(event.key);
+  let input = document.querySelector('#inputField')
+  let value = input.value;
+  let newVal = value;
+  switch(event.key){
+    case 'Backspace':
+      newVal = value.slice(0,value.length-1);
+      break;
+    case 'Shift':
+    case 'Enter':
+      break;
+    
+    default:
+      newVal = value +event.key
+  }
+  input.value = newVal;
+})

--- a/exhibitera/apps/word_cloud_input.html
+++ b/exhibitera/apps/word_cloud_input.html
@@ -31,8 +31,9 @@
         <div class='col-3 col-lg-2'>
           <button id="clearButton" class='btn btn-secondary w-100'>Clear</button>
         </div>
-        <div class='col-6 col-lg-8'>
+        <div class='annotatedInput col-6 col-lg-8'>
           <input id="inputField" class="input w-100 form-control" placeholder="Type to enter response" readonly/>
+          <div id="characterCount"></div>
         </div>
         <div class='col-3 col-lg-2'>
           <button id="submitButton" class='btn btn-secondary w-100'>Submit</button>


### PR DESCRIPTION
Adding in the ability of a keyboard to be used for entering text into the Word Cloud. This includes a toggle-able setting during setup, and defaults to off. If this setting is enabled it will hide the on screen keyboard at the moment. 

Additionally I thought there would be value in also being able to control the max character length of an entered word if desired. I added in that setting as well, with its default state to not do anything. It also will display a character count to the user if there is one enabled. (Color can be controlled through settings)

This addresses issue #6 

Samples: 
<img width="392" alt="Screenshot 2024-04-28 at 5 54 35 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/a56bf9e1-2bc3-48d2-b14b-56fd5b6ba252">
<img width="789" alt="Screenshot 2024-04-28 at 5 54 12 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/f0f1b95c-4b05-4744-a698-9f6bf3b64abc">
<img width="802" alt="Screenshot 2024-04-28 at 5 53 58 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/fbb6ba18-576d-4493-ae33-9a7c2163a3a1">
<img width="797" alt="Screenshot 2024-04-28 at 5 53 43 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/14c49532-2e2f-4acf-9958-98d9611e7028">

<img width="770" alt="Screenshot 2024-04-28 at 5 53 26 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/619862b5-a08e-4b3f-91ad-51a6330859f3">

<img width="1708" alt="Screenshot 2024-04-28 at 6 19 17 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/276a7c9e-4f27-475b-82d5-51cf65e7deff">
<img width="1147" alt="Screenshot 2024-04-28 at 6 26 44 PM" src="https://github.com/Cosmic-Chatter/Exhibitera/assets/790022/0cf385af-32b1-4282-a5f2-904b74981acb">
